### PR TITLE
Schema updates for #6.

### DIFF
--- a/marketo_rest.install
+++ b/marketo_rest.install
@@ -6,6 +6,46 @@
  */
 
 /**
+ * Implements hook_schema().
+ */
+function marketo_rest_webform_schema() {
+  $schema = array();
+  $schema[MARKETO_REST_SCHEMA_LEAD_FIELDS] = array(
+    'description' => 'Marketo Lead Field Details',
+    'primary key' => array(MARKETO_REST_LEAD_FIELD_ID),
+    'unique keys' => array(MARKETO_REST_LEAD_FIELD_ID),
+    'fields' => array(
+      MARKETO_REST_LEAD_FIELD_ID => array(
+        'description' => 'The Marketo identifier of a field.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      MARKETO_REST_LEAD_FIELD_REST_KEY => array(
+        'description' => 'The Marketo lead field key for REST API.',
+        'type' => 'varchar',
+        'length' => 128,
+      ),
+      MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => array(
+        'description' => 'The Marketo lead field key for Munchkin API.',
+        'type' => 'varchar',
+        'length' => 128,
+      ),
+      'enabled' => array(
+        'description' => 'Marketo field enabled or disabled.',
+        'type' => 'int',
+        'size' => 'small',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+  );
+  return $schema;
+}
+
+/**
  * Implements hook_uninstall().
  */
 function marketo_rest_uninstall() {

--- a/marketo_rest.install
+++ b/marketo_rest.install
@@ -8,7 +8,7 @@
 /**
  * Implements hook_schema().
  */
-function marketo_rest_webform_schema() {
+function marketo_rest_schema() {
   $schema = array();
   $schema[MARKETO_REST_SCHEMA_LEAD_FIELDS] = array(
     'description' => 'Marketo Lead Field Details',

--- a/marketo_rest.module
+++ b/marketo_rest.module
@@ -18,14 +18,17 @@ define('MARKETO_REST_PAGING_TOKEN_API', 'activities/pagingtoken.json');
 
 define('MARKETO_REST_PAGES', "admin\nadmin/*\nbatch\nnode/add*\nnode/*/*\nuser/*/*");
 define('MARKETO_REST_TRACKING_METHOD_DEFAULT', 'munchkin');
-define('MARKETO_REST_WEBFORM_FIELD_DEFAULTS', "firstName|First Name\nlastName|Last Name\nemail|Email Address");
+
+define('MARKETO_REST_SCHEMA_LEAD_FIELDS', 'marketo_rest_lead_fields');
+define('MARKETO_REST_LEAD_FIELD_ID', 'marketo_id');
+define('MARKETO_REST_LEAD_FIELD_REST_KEY', 'marketo_rest_key');
+define('MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY', 'marketo_munchkin_key');
 
 define('MARKETO_REST_SCHEMA_WEBFORM', 'marketo_rest_webform');
 define('MARKETO_REST_WEBFORM_FIELD_ACTIVE', 'is_active');
 define('MARKETO_REST_WEBFORM_OPTIONS', 'options');
 
 define('MARKETO_REST_SCHEMA_WEBFORM_COMPONENT', 'marketo_rest_webform_component');
-define('MARKETO_REST_WEBFORM_COMPONENT_KEY', 'marketo_rest_key');
 define('MARKETO_REST_WEBFORM_COMPONENT_NONE', 'none');
 
 /**

--- a/webform/marketo_rest_webform.install
+++ b/webform/marketo_rest_webform.install
@@ -55,10 +55,12 @@ function marketo_rest_webform_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      MARKETO_REST_WEBFORM_COMPONENT_KEY => array(
-        'description' => 'The Marketo form field.',
-        'type' => 'varchar',
-        'length' => 128,
+      MARKETO_REST_LEAD_FIELD_ID => array(
+        'description' => 'The Marketo identifier of a field.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
       ),
     ),
   );


### PR DESCRIPTION
@neclimdul Here is a first pass at schema updates. I put the new table in the main module install file to allow for reuse outside of webform submodule and modified the webform submodule install file to use the new `marketo_id`.

[MARKETO_REST_WEBFORM_FIELD_DEFAULTS](https://github.com/mccrodp/marketo_rest/blob/7.x-1.x/marketo_rest.module#L21) was removed and will need to be addressed. I'm not sure where though, so maybe that should be the second commit in this PR along with any changes from your review.

I have created a new parent branch _fix-munchkin-api_ for this fix and sub branches can be off that for the separate items that need addressing, i.e. - schema, new local task field interface (replacing "Field Definitions" tab), describe.json / `prepareFields()` usage, field mapping methods based on 
[MARKETO_REST_LEAD_FIELD_ID](https://github.com/mccrodp/marketo_rest/blob/fix-munchkin-api-schema-updates/marketo_rest.module#L23) used in Webform's "Marketo" tab, etc.
