### PR TITLE
Add checboxes to the UI and associated get(), set() and merge() methods.

### DIFF
--- a/includes/marketo_rest.admin.inc
+++ b/includes/marketo_rest.admin.inc
@@ -252,45 +252,65 @@ function marketo_rest_field_definition_form($form, &$form_state) {
   $form['marketo_rest_fields'] = array(
     '#title' => t('Field Definition'),
     '#type' => 'fieldset',
-    '#description' => t('The fields defined here will be available for mapping to Webform and User Profile fields'),
+    '#description' => t('Enable / disable the fields defined here for mapping to Webform and User Profile fields.'),
   );
-  $form['marketo_rest_fields']['marketo_rest_webform_fields'] = array(
-    '#type' => 'textarea',
-    '#title' => t('Marketo fields'),
-    '#description' => t('Pipe "|" delimited strings of [API Name]|[Friendly Label]. Enter one field per line. This information can be found in the Marketo admin page at Admin > Field Management > Export Field Names.<p>Once REST API settings have been configured, these fields can be automatically obtained from Marketo using the button below</p>'),
-    '#rows' => 10,
-    '#prefix' => '<div id="marketo-webform-fields-wrapper">',
+
+  $field_options = _marketo_rest_get_field_options();
+
+  if (isset($form_state['triggering_element']['#array_parents']) && in_array('marketo_rest_lead_fields_rest', $form_state['triggering_element']['#array_parents'])) {
+    $marketo_fields = array();
+    $fields = _marketo_rest_get_fields();
+    foreach ($fields as $id => $field) {
+      $marketo_fields[$id] = $field['displayName'];
+    }
+    // Make field data accessible to callback.
+    $form['#marketo-fields'] = $fields;
+    $field_options = _marketo_rest_merge_field_options($field_options, $marketo_fields);
+  }
+
+  $form['marketo_rest_fields']['marketo_rest_lead_fields'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Marketo Fields'),
+    '#default_value' => array(/*3=>'3', 2=>0*/),
+    '#options' => $field_options,
+    '#prefix' => '<div id="marketo-lead-fields-wrapper">',
     '#suffix' => '</div>',
   );
 
-  if (isset($form_state['triggering_element']['#array_parents']) && in_array('marketo_rest_webform_fields_rest', $form_state['triggering_element']['#array_parents'])) {
-    $data = _marketo_rest_get_fields();
-    $mwf_default = "";
-    foreach ($data as $key => $value) {
-      $mwf_default .= $key . "|" . $value['displayName'] . "\n";
-    }
-    $form['marketo_rest_fields']['marketo_rest_webform_fields']['#value'] = $mwf_default;
-  }
-  else {
-    $form['marketo_rest_fields']['marketo_rest_webform_fields']['#default_value'] = variable_get('marketo_rest_webform_fields', MARKETO_REST_WEBFORM_FIELD_DEFAULTS);
-  }
-
-  $form['marketo_rest_fields']['marketo_rest_webform_fields_rest'] = array(
+  $form['marketo_rest_fields']['marketo_rest_lead_fields_rest'] = array(
     '#type' => 'button',
     '#value' => t('Retrieve from Marketo'),
     '#ajax' => array(
       'callback' => '_marketo_rest_webform_fields_rest_callback',
-      'wrapper' => 'marketo-webform-fields-wrapper',
+      'wrapper' => 'marketo-lead-fields-wrapper',
     ),
   );
 
   // If REST settings have not been configured, the button should be disabled.
   if (!_marketo_rest_rest_is_configured()) {
-    $form['marketo_rest_fields']['marketo_rest_webform_fields_rest']['#disabled'] = TRUE;
+    $form['marketo_rest_fields']['marketo_rest_lead_fields_rest']['#disabled'] = TRUE;
   }
+
+  // Add a submit handler.
+  $form['#submit'][] = 'marketo_rest_field_definition_form_submit';
 
   return system_settings_form($form);
 }
+
+/**
+ * Form definition submit callback.
+ *
+ * @param $form
+ * @param $form_state
+ */
+function marketo_rest_field_definition_form_submit($form, &$form_state) {
+  // When we have retrieved marketo fields, we may need to map new fields.
+  if (!empty($form['#marketo-fields'])) {
+    _marketo_rest_sync_field_definitions($form_state['values']['marketo_rest_lead_fields'], $form['#marketo-fields']);
+  }
+  _marketo_rest_sync_field_definitions($form_state['values']['marketo_rest_lead_fields']);
+}
+
 
 /**
  * Performs validation for Marketo REST API settings.
@@ -329,5 +349,5 @@ function _marketo_rest_validate_rest_configuration($client_id, $client_secret, $
  * Callback for updating webform fields.
  */
 function _marketo_rest_webform_fields_rest_callback($form, &$form_state) {
-  return $form['marketo_rest_fields']['marketo_rest_webform_fields'];
+  return $form['marketo_rest_fields']['marketo_rest_lead_fields'];
 }

--- a/includes/marketo_rest.admin.inc
+++ b/includes/marketo_rest.admin.inc
@@ -268,10 +268,17 @@ function marketo_rest_field_definition_form($form, &$form_state) {
     $field_options = _marketo_rest_merge_field_options($field_options, $marketo_fields);
   }
 
+  $field_values = array();
+
+  // When we have fields, get enabled / disabled values.
+  if (!empty($field_options)) {
+    $field_values = _marketo_rest_get_field_values();
+  }
+
   $form['marketo_rest_fields']['marketo_rest_lead_fields'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Marketo Fields'),
-    '#default_value' => array(/*3=>'3', 2=>0*/),
+    '#default_value' => $field_values,
     '#options' => $field_options,
     '#prefix' => '<div id="marketo-lead-fields-wrapper">',
     '#suffix' => '</div>',

--- a/includes/marketo_rest.rest.inc
+++ b/includes/marketo_rest.rest.inc
@@ -758,8 +758,8 @@ class MarketoRestClient implements MarketoRestInterface {
     if (!empty($result['result'])) {
       $fields = array();
       foreach ($result['result'] as $field) {
-        if (!empty($field['rest']['name'])) {
-          $fields[$field['rest']['name']] = $field;
+        if (!empty($field['id'])) {
+          $fields[$field['id']] = $field;
         }
       }
       return $fields;

--- a/marketo_rest.install
+++ b/marketo_rest.install
@@ -25,6 +25,7 @@ function marketo_rest_schema() {
         'description' => 'The Marketo lead field display name.',
         'type' => 'varchar',
         'length' => 128,
+        'not null' => TRUE,
       ),
       MARKETO_REST_LEAD_FIELD_REST_KEY => array(
         'description' => 'The Marketo lead field key for REST API.',

--- a/marketo_rest.install
+++ b/marketo_rest.install
@@ -21,6 +21,11 @@ function marketo_rest_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'name' => array(
+        'description' => 'The Marketo lead field display name.',
+        'type' => 'varchar',
+        'length' => 128,
+      ),
       MARKETO_REST_LEAD_FIELD_REST_KEY => array(
         'description' => 'The Marketo lead field key for REST API.',
         'type' => 'varchar',

--- a/marketo_rest.module
+++ b/marketo_rest.module
@@ -53,7 +53,7 @@ function marketo_rest_menu() {
   );
 
   // Field definition form.
-  $items['admin/config/search/marketo_rest/field-definition'] = array(
+  $items['admin/config/search/marketo_rest/field_definition'] = array(
     'title' => 'Field Definition',
     'description' => 'Marketo REST field definition',
     'page callback' => 'drupal_get_form',
@@ -412,10 +412,33 @@ function _marketo_rest_get_field_options($labels = TRUE, $sort = TRUE) {
 
   // Cycle through each field return the marketo field id => display name array.
   foreach ($fields as $id => $field) {
-    $options[$id] = $field['name'];
+    $options[$id] = $field->name;
   }
 
   return $options;
+}
+
+/**
+ * Returns defined field values as a marketo_id|value array.
+ *
+ * @return array
+ *   Key/value pairs of defined Marketo fields
+ */
+function _marketo_rest_get_field_values() {
+
+  $values = array();
+  $fields = _marketo_rest_get_field_definitions();
+
+  // Cycle through each field return the marketo field id => enabled array.
+  foreach ($fields as $id => $field) {
+    $value = 0;
+    if ($field->enabled) {
+      $value = $id;
+    }
+    $values[$id] = $value;
+  }
+
+  return $values;
 }
 
 /**
@@ -749,12 +772,16 @@ function _marketo_rest_sync_field_definitions(array $values, array $fields = nul
   // When we have marketo fields array, merge fields in db.
   if (!empty($fields) && is_array($fields)) {
     foreach ($fields as $id => $field) {
+      $display_name = $field['displayName'];
+      $rest_name = (!empty($field['rest']['name'])) ? $field['rest']['name'] : null;
+      $munchkin_name = (!empty($field['soap']['name'])) ? $field['soap']['name'] : null;
+
       db_merge(MARKETO_REST_SCHEMA_LEAD_FIELDS)
         ->key(array(MARKETO_REST_LEAD_FIELD_ID => $id))
         ->fields(array(
-          'name' => $field['displayName'],
-          MARKETO_REST_LEAD_FIELD_REST_KEY => $field['rest']['name'],
-          MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => $field['soap']['name'],
+          'name' => $display_name,
+          MARKETO_REST_LEAD_FIELD_REST_KEY => $rest_name,
+          MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => $munchkin_name,
           'enabled' => !empty($values[$id]) ? 1 : 0,
         ))
         ->execute();
@@ -762,11 +789,11 @@ function _marketo_rest_sync_field_definitions(array $values, array $fields = nul
   } else {
     // When we are updating existing fields in the db only.
     foreach ($values as $id => $value) {
-      db_merge(MARKETO_REST_SCHEMA_LEAD_FIELDS)
-        ->key(array(MARKETO_REST_LEAD_FIELD_ID => $id))
+      db_update(MARKETO_REST_SCHEMA_LEAD_FIELDS)
         ->fields(array(
           'enabled' => !empty($value) ? 1 : 0,
         ))
+        ->condition(MARKETO_REST_LEAD_FIELD_ID, $id)
         ->execute();
     }
   }
@@ -779,12 +806,14 @@ function _marketo_rest_sync_field_definitions(array $values, array $fields = nul
  */
 function _marketo_rest_get_field_definitions() {
   $data = array();
-  $result = db_select(MARKETO_REST_SCHEMA_LEAD_FIELDS)
+  $result = db_select(MARKETO_REST_SCHEMA_LEAD_FIELDS, 'f')
+    ->fields('f')
     ->execute()
     ->fetchAll();
   foreach ($result as $field) {
     $data[$field->{MARKETO_REST_LEAD_FIELD_ID}] = $field;
   }
+
   return $data;
 }
 

--- a/marketo_rest.module
+++ b/marketo_rest.module
@@ -406,25 +406,13 @@ function _marketo_rest_queue_lead($lead) {
  *   Key/value pairs of defined Marketo fields
  */
 function _marketo_rest_get_field_options($labels = TRUE, $sort = TRUE) {
-  /*
-   * marketo_rest_webform_fields is multi-line, pipe "|" delimited data
-   * which needs to be parsed. First split it into rows of data.
-   */
-  $raw_options = preg_split('/(\r\n?|\n)/', trim(variable_get('marketo_rest_webform_fields', MARKETO_REST_WEBFORM_FIELD_DEFAULTS)));
-  $options = array();
 
-  // Loop over all the rows getting the keys and values for the fields.
-  foreach ($raw_options as $row) {
-    $field = explode('|', trim($row));
-    if ($labels) {
-      $options[trim($field[0])] = trim($field[1]) . ' (' . trim($field[0]) . ')';
-    }
-    else {
-      $options[trim($field[0])] = trim($field[1]);
-    }
-  }
-  if ($sort) {
-    asort($options);
+  $options = array();
+  $fields = _marketo_rest_get_field_definitions();
+
+  // Cycle through each field return the marketo field id => display name array.
+  foreach ($fields as $id => $field) {
+    $options[$id] = $field['name'];
   }
 
   return $options;
@@ -749,4 +737,64 @@ function _marketo_rest_rest_proxy_settings() {
  */
 function _marketo_rest_persist_access_token($access_token, $expiry) {
   variable_set('marketo_rest_token', array('access_token' => $access_token, 'expiry' => $expiry));
+}
+
+/**
+ * Sync the lead field names in the database.
+ *
+ * @param array $values
+ * @param array|NULL $fields
+ */
+function _marketo_rest_sync_field_definitions(array $values, array $fields = null) {
+  // When we have marketo fields array, merge fields in db.
+  if (!empty($fields) && is_array($fields)) {
+    foreach ($fields as $id => $field) {
+      db_merge(MARKETO_REST_SCHEMA_LEAD_FIELDS)
+        ->key(array(MARKETO_REST_LEAD_FIELD_ID => $id))
+        ->fields(array(
+          'name' => $field['displayName'],
+          MARKETO_REST_LEAD_FIELD_REST_KEY => $field['rest']['name'],
+          MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => $field['soap']['name'],
+          'enabled' => !empty($values[$id]) ? 1 : 0,
+        ))
+        ->execute();
+    }
+  } else {
+    // When we are updating existing fields in the db only.
+    foreach ($values as $id => $value) {
+      db_merge(MARKETO_REST_SCHEMA_LEAD_FIELDS)
+        ->key(array(MARKETO_REST_LEAD_FIELD_ID => $id))
+        ->fields(array(
+          'enabled' => !empty($value) ? 1 : 0,
+        ))
+        ->execute();
+    }
+  }
+}
+
+/**
+ * Get the field definition data.
+ *
+ * @return array
+ */
+function _marketo_rest_get_field_definitions() {
+  $data = array();
+  $result = db_select(MARKETO_REST_SCHEMA_LEAD_FIELDS)
+    ->execute()
+    ->fetchAll();
+  foreach ($result as $field) {
+    $data[$field->{MARKETO_REST_LEAD_FIELD_ID}] = $field;
+  }
+  return $data;
+}
+
+/**
+ * Merge existing field definitions with fields retrieved from Marketo.
+ *
+ * @param $field_options
+ * @param $marketo_fields
+ * @return array
+ */
+function _marketo_rest_merge_field_options($field_options, $marketo_fields) {
+  return array_merge($field_options, $marketo_fields);
 }

--- a/tests/features/admin/configure.feature
+++ b/tests/features/admin/configure.feature
@@ -32,6 +32,18 @@ Feature: Module configuration
     When I press "Save configuration"
     Then I should see "Unable to validate REST API settings."
   
+  @config @field_definitions
+  Scenario: Configure field definition settings
+    Given I populate the Marketo REST config using "marketo_settings"
+    When I am logged in as an administrator
+    And I go to "/admin/config/search/marketo_rest/field_definition"
+    When I press "Retrieve from Marketo"
+    Then I should see have field definition:
+      |    marketo_rest_key    |    marketo_munchkin_key      |    enabled      |
+      |    email               |        Email                 |      1          |
+      |    lastName            |        LastName              |      1          |
+      |    firstName           |        FirstName             |      1          |
+
   @config @live
   Scenario: Configure live module settings
     Given I populate the Marketo REST config using "marketo_settings"


### PR DESCRIPTION
Another PR relating to: https://github.com/mccrodp/marketo_rest/issues/6.

@neclimdul - Here's start at the checkboxes in the UI and associated db & presentation functions.

Hope to get onto creating some tests for this later and also how we use the display `name` on the "Marketo" tab of Webform nodes to associate field mapping by `marketo_id`.
