### PR TITLE
Add field definitions tests [incl. change checkboxes to tableselect]

### DIFF
--- a/includes/marketo_rest.admin.inc
+++ b/includes/marketo_rest.admin.inc
@@ -277,8 +277,8 @@ function marketo_rest_field_definition_form($form, &$form_state) {
     '#header' => array(
       MARKETO_REST_LEAD_FIELD_ID => t('Marketo ID'),
       'name' => t('Display name'),
-      MARKETO_REST_LEAD_FIELD_REST_KEY => t('REST name'),
-      MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => t('Munchkin name'),
+      MARKETO_REST_LEAD_FIELD_REST_KEY => t('REST key'),
+      MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => t('Munchkin key'),
     ),
     '#options' => $field_options,
     '#default_value' => $field_values,

--- a/includes/marketo_rest.admin.inc
+++ b/includes/marketo_rest.admin.inc
@@ -255,31 +255,33 @@ function marketo_rest_field_definition_form($form, &$form_state) {
     '#description' => t('Enable / disable the fields defined here for mapping to Webform and User Profile fields.'),
   );
 
-  $field_options = _marketo_rest_get_field_options();
+  $field_definitions = _marketo_rest_get_field_definitions();
+  $field_options = _marketo_rest_get_field_tableselect_options($field_definitions);
 
   if (isset($form_state['triggering_element']['#array_parents']) && in_array('marketo_rest_lead_fields_rest', $form_state['triggering_element']['#array_parents'])) {
-    $marketo_fields = array();
-    $fields = _marketo_rest_get_fields();
-    foreach ($fields as $id => $field) {
-      $marketo_fields[$id] = $field['displayName'];
-    }
+    $marketo_fields = _marketo_rest_get_fields();
     // Make field data accessible to callback.
-    $form['#marketo-fields'] = $fields;
-    $field_options = _marketo_rest_merge_field_options($field_options, $marketo_fields);
+    $form['#marketo-fields'] = $marketo_fields;
+    $field_options += $marketo_fields; // Only merge new array keys.
   }
 
   $field_values = array();
 
   // When we have fields, get enabled / disabled values.
   if (!empty($field_options)) {
-    $field_values = _marketo_rest_get_field_values();
+    $field_values = _marketo_rest_get_field_tableselect_values($field_definitions);
   }
 
   $form['marketo_rest_fields']['marketo_rest_lead_fields'] = array(
-    '#type' => 'checkboxes',
-    '#title' => t('Marketo Fields'),
-    '#default_value' => $field_values,
+    '#type' => 'tableselect',
+    '#header' => array(
+      MARKETO_REST_LEAD_FIELD_ID => t('Marketo ID'),
+      'name' => t('Display name'),
+      MARKETO_REST_LEAD_FIELD_REST_KEY => t('REST name'),
+      MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => t('Munchkin name'),
+    ),
     '#options' => $field_options,
+    '#default_value' => $field_values,
     '#prefix' => '<div id="marketo-lead-fields-wrapper">',
     '#suffix' => '</div>',
   );

--- a/includes/marketo_rest.rest.inc
+++ b/includes/marketo_rest.rest.inc
@@ -759,7 +759,13 @@ class MarketoRestClient implements MarketoRestInterface {
       $fields = array();
       foreach ($result['result'] as $field) {
         if (!empty($field['id'])) {
-          $fields[$field['id']] = $field;
+          $fields[$field['id']] = array(
+            MARKETO_REST_LEAD_FIELD_ID => $field['id'],
+            'name' => isset($field['displayName']) ? $field['displayName'] : '',
+            MARKETO_REST_LEAD_FIELD_REST_KEY => isset($field['rest']['name']) ? $field['rest']['name'] : '',
+            MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => isset($field['soap']['name']) ? $field['soap']['name'] : '',
+            'enabled' => 0,
+          );
         }
       }
       return $fields;

--- a/marketo_rest.module
+++ b/marketo_rest.module
@@ -405,10 +405,14 @@ function _marketo_rest_queue_lead($lead) {
  * @return array
  *   Key/value pairs of defined Marketo fields
  */
-function _marketo_rest_get_field_options($labels = TRUE, $sort = TRUE) {
+function _marketo_rest_get_field_options($fields = null) {
 
   $options = array();
-  $fields = _marketo_rest_get_field_definitions();
+
+  // Get field definitions if not passed as an arg.
+  if (!$fields) {
+    $fields = _marketo_rest_get_field_definitions();
+  }
 
   // Cycle through each field return the marketo field id => display name array.
   foreach ($fields as $id => $field) {
@@ -424,10 +428,13 @@ function _marketo_rest_get_field_options($labels = TRUE, $sort = TRUE) {
  * @return array
  *   Key/value pairs of defined Marketo fields
  */
-function _marketo_rest_get_field_values() {
+function _marketo_rest_get_field_tableselect_values($fields = null) {
 
   $values = array();
-  $fields = _marketo_rest_get_field_definitions();
+  // Get field definitions if not passed as an arg.
+  if (!$fields) {
+    $fields = _marketo_rest_get_field_definitions();
+  }
 
   // Cycle through each field return the marketo field id => enabled array.
   foreach ($fields as $id => $field) {
@@ -439,6 +446,35 @@ function _marketo_rest_get_field_values() {
   }
 
   return $values;
+}
+
+/**
+ * Returns defined fields as an associative for tableselect list options.
+ *
+ * @return array
+ *   Key/value pairs of defined Marketo fields
+ */
+function _marketo_rest_get_field_tableselect_options($fields = null) {
+
+  $options = array();
+
+  // Get field definitions if not passed as an arg.
+  if (!$fields) {
+    $fields = _marketo_rest_get_field_definitions();
+  }
+
+  // Cycle through each field returning the tableselect field values.
+  foreach ($fields as $id => $field) {
+    $options[$id] = array(
+      MARKETO_REST_LEAD_FIELD_ID => $id,
+      'name' => isset($field->name) ? $field->name : '',
+      MARKETO_REST_LEAD_FIELD_REST_KEY => isset($field->marketo_rest_key) ? $field->marketo_rest_key : '',
+      MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => isset($field->marketo_munchkin_key) ? $field->marketo_munchkin_key : '',
+      'enabled' => $field->enabled,
+    );
+  }
+
+  return $options;
 }
 
 /**
@@ -772,18 +808,9 @@ function _marketo_rest_sync_field_definitions(array $values, array $fields = nul
   // When we have marketo fields array, merge fields in db.
   if (!empty($fields) && is_array($fields)) {
     foreach ($fields as $id => $field) {
-      $display_name = $field['displayName'];
-      $rest_name = (!empty($field['rest']['name'])) ? $field['rest']['name'] : null;
-      $munchkin_name = (!empty($field['soap']['name'])) ? $field['soap']['name'] : null;
-
       db_merge(MARKETO_REST_SCHEMA_LEAD_FIELDS)
         ->key(array(MARKETO_REST_LEAD_FIELD_ID => $id))
-        ->fields(array(
-          'name' => $display_name,
-          MARKETO_REST_LEAD_FIELD_REST_KEY => $rest_name,
-          MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY => $munchkin_name,
-          'enabled' => !empty($values[$id]) ? 1 : 0,
-        ))
+        ->fields($field)
         ->execute();
     }
   } else {

--- a/tests/features/admin/configure.feature
+++ b/tests/features/admin/configure.feature
@@ -34,15 +34,15 @@ Feature: Module configuration
   
   @config @field_definitions
   Scenario: Configure field definition settings
-    Given I populate the Marketo REST config using "marketo_settings"
+    Given all Marketo REST modules are clean and using "marketo_settings"
+    And I have instantiated the Marketo rest client using "marketo_settings"
     When I am logged in as an administrator
     And I go to "/admin/config/search/marketo_rest/field_definition"
     When I press "Retrieve from Marketo"
     Then I should see have field definition:
-      |    marketo_rest_key    |    marketo_munchkin_key      |    enabled      |
-      |    email               |        Email                 |      1          |
-      |    lastName            |        LastName              |      1          |
-      |    firstName           |        FirstName             |      1          |
+     | marketo_id |     name      |   marketo_rest_key    |    marketo_munchkin_key      |    enabled      |
+     |    2       | Company Name  |       company         |        Company               |      0          |
+     |    3       | Site          |       site            |        Site                  |      0          |
 
   @config @live
   Scenario: Configure live module settings

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -944,4 +944,21 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     }
   }
 
+  /**
+   * @Then /^I should see have field definition:$/
+   */
+  public function iShouldSeeHaveFieldDefinition(TableNode $table)
+  {
+    try {
+      $data = $this->getAssocDataArrayObjs($table->getRows());
+      $field_definitions = _marketo_rest_get_field_definitions();
+      if ($data != $field_definitions) {
+        throw new Exception('Field definitions don\'t match expected data.');
+      }
+    }
+    catch (Exception $e) {
+      throw new Exception($e->getMessage());
+    }
+  }
+
 }

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -950,10 +950,14 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   public function iShouldSeeHaveFieldDefinition(TableNode $table)
   {
     try {
-      $data = $this->getAssocDataArrayObjs($table->getRows());
+      $rows = $this->getAssocDataArrayObjs($table->getRows());
       $field_definitions = _marketo_rest_get_field_definitions();
-      if ($data != $field_definitions) {
-        throw new Exception('Field definitions don\'t match expected data.');
+      foreach ($rows as $fields) {
+        foreach ($fields as $key => $value) {
+          if ($field_definitions[$fields->marketo_id]->{$key} != $value) {
+            throw new Exception('Field definitions don\'t contain expected data.');
+          }
+        }
       }
     }
     catch (Exception $e) {

--- a/user/marketo_rest_user.module
+++ b/user/marketo_rest_user.module
@@ -231,7 +231,7 @@ function _marketo_rest_user_display_lead($account) {
   return theme('marketo_rest_user_lead', array(
     'lead' => $leads,
     'email' => $account->mail,
-    'fields' => _marketo_rest_get_field_options(FALSE, FALSE),
+    'fields' => _marketo_rest_get_field_options(),
   ));
 }
 

--- a/webform/marketo_rest_webform.module
+++ b/webform/marketo_rest_webform.module
@@ -153,7 +153,7 @@ function _marketo_rest_webform_get_mapped_fields($nid) {
     ->execute()
     ->fetchAll();
   foreach ($result as $field) {
-    $data[$field->cid] = $field->marketo_rest_key;
+    $data[$field->cid] = $field->marketo_id;
   }
   return $data;
 }
@@ -215,8 +215,8 @@ function marketo_rest_webform_list() {
   if ($webform_types) {
     $components = db_select(MARKETO_REST_SCHEMA_WEBFORM_COMPONENT, 'mmwc');
     $components->addField('mmwc', 'nid');
-    $components->addExpression('count(' . MARKETO_REST_WEBFORM_COMPONENT_KEY . ')', 'components');
-    $components->condition('marketo_rest_key', 'none', '<>');
+    $components->addExpression('count(' . MARKETO_REST_LEAD_FIELD_ID . ')', 'components');
+    $components->condition(MARKETO_REST_LEAD_FIELD_ID, 'none', '<>');
     $components->groupBy('nid');
 
     $nodes = db_select('node', 'n');


### PR DESCRIPTION
Adding tests for Field Definitions admin UI as part of: https://github.com/mccrodp/marketo_rest/pull/11

Added tableselect to allow for select all checkboxes and display of field names.
<img width="1145" alt="screen shot 2016-08-07 at 14 19 59" src="https://cloud.githubusercontent.com/assets/559938/17462805/3442e450-5cb0-11e6-8204-c6208589627d.png">
