### PR TITLE
Fix munchkin field formating

### DIFF
--- a/includes/marketo_rest.data.inc
+++ b/includes/marketo_rest.data.inc
@@ -179,7 +179,7 @@ class MarketoRestData implements MarketoData {
             ->fetchAll();
           // Cycle through the result row(s) and set the new munchkin field key.
           foreach ($result as $field) {
-            if (isset($formatted_data[$field->{MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY}])) {
+            if (isset($field->{MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY})) {
               $formatted_data[$field->{MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY}] = $value;
             }
           }


### PR DESCRIPTION
Just a typo. Since formatted_data never gets a value the if always fails. We really
want to assert we have a munchkin key for the specified field.
