### PR TITLE
Fix token persistence.

### DIFF
--- a/marketo_rest.module
+++ b/marketo_rest.module
@@ -817,7 +817,7 @@ function _marketo_rest_rest_proxy_settings() {
  * @param $expiry
  */
 function _marketo_rest_persist_access_token($access_token, $expiry) {
-  variable_set('marketo_rest_token', array('access_token' => $access_token, 'expiry' => $expiry));
+  variable_set('marketo_rest_token', array('access_token' => $access_token, 'token_expiry' => $expiry));
 }
 
 /**


### PR DESCRIPTION
The token storage index was incorrect and we requested a token each REST request.

Fixed now.
